### PR TITLE
add support for transparent terminal backgrounds

### DIFF
--- a/src/about.cpp
+++ b/src/about.cpp
@@ -29,7 +29,7 @@ AboutWin::AboutWin(int rows, int cols) : NGroup(NRect(rows, cols, getmaxy(stdscr
     modalflag = true;
     caption = strdup(" BOINCTUI ");
     resize(10,getwidth());
-    wattrset(win,getcolorpair(COLOR_WHITE, COLOR_BLACK) | A_BOLD);
+    wattrset(win,getcolorpair(COLOR_WHITE, -1) | A_BOLD);
     if(asciilinedraw == 1)
 	wborder(win, '|', '|', '-', '-', '+', '+', '+', '+');
     else

--- a/src/addmgrform.cpp
+++ b/src/addmgrform.cpp
@@ -94,7 +94,7 @@ void AddAccMgrForm::genfields(int& line, Item* mgr) //создаст масси�
     //имя менеджера
     f = addfield(new_field(1, getwidth()-4, line, 2, 0, 0));
     set_field_buffer(f, 0, "Description  ");
-    set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD);
+    set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD);
     field_opts_off(f, O_ACTIVE); //статический текст
     namefield = getfieldcount();
     f = addfield(new_field(1, 40, line++, 15, 0, 0));
@@ -118,7 +118,7 @@ void AddAccMgrForm::genfields(int& line, Item* mgr) //создаст масси�
     line++;
     f = addfield(new_field(1, getwidth()-4, line, 2, 0, 0));
     set_field_buffer(f, 0, "URL          ");
-    set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD);
+    set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD);
     field_opts_off(f, O_ACTIVE); //статический текст
     urlfield = getfieldcount();
     f = addfield(new_field(1, 40, line++, 15, 0, 0));
@@ -137,14 +137,14 @@ void AddAccMgrForm::genfields(int& line, Item* mgr) //создаст масси�
     f = addfield(new_field(3, getwidth()-4, line++, 2, 0, 0));
     set_field_buffer(f, 0,  "If you have not yet registered with this account manager" \
     			"     please do so before proceeding.");
-    set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD);
+    set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD);
     field_opts_off(f, O_ACTIVE); //статический текст
     line = line + 2;
     //user name
     line++;
     f = addfield(new_field(1, 10, line, 2 , 0, 0));
     set_field_buffer(f, 0, "username");
-    set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD);
+    set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD);
     field_opts_off(f, O_ACTIVE); //статический текст
     usernamefield = getfieldcount();
     f = addfield(new_field(1, 40, line++, 15, 0, 0));
@@ -154,7 +154,7 @@ void AddAccMgrForm::genfields(int& line, Item* mgr) //создаст масси�
     line++;
     f = addfield(new_field(1, 10, line, 2 , 0, 0));
     set_field_buffer(f, 0, "password");
-    set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD);
+    set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD);
     field_opts_off(f, O_ACTIVE); //статический текст
     passwfield = getfieldcount();
     f = addfield(new_field(1, 40, line++, 15, 0, 0));
@@ -164,7 +164,7 @@ void AddAccMgrForm::genfields(int& line, Item* mgr) //создаст масси�
     line++;
     f = addfield(new_field(1, getwidth()-25, line++, 20 , 0, 0));
     set_field_buffer(f, 0, "Enter-Ok    Esc-Cancel");
-    set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD);
+    set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD);
     field_opts_off(f, O_ACTIVE); //статический текст
     //финализация списка полей
     addfield(NULL);

--- a/src/addprojectform.cpp
+++ b/src/addprojectform.cpp
@@ -103,7 +103,7 @@ void AddProjectForm::genfields(int& line, Item* project) //создаст мас
 	f = addfield(new_field(1, getwidth()-4, line++, 1, 0, 0));
 	if (E_OK != set_field_buffer(f, 0, s.c_str()))
 	    ERROREX();
-	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD))
+	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD))
 	    ERROREX();
 	if (E_OK != field_opts_off(f, O_ACTIVE)) //статический текст
 	    ERROREX();
@@ -117,7 +117,7 @@ void AddProjectForm::genfields(int& line, Item* project) //создаст мас
 	    ERROREX();
 	if (E_OK != set_field_buffer(f, 0, s.c_str()))
 	    ERROREX();
-	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD))
+	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD))
 	    ERROREX();
 	if (E_OK != field_opts_off(f, O_ACTIVE)) //статический текст
 	    ERROREX();
@@ -131,7 +131,7 @@ void AddProjectForm::genfields(int& line, Item* project) //создаст мас
 	    ERROREX();
 	if (E_OK != set_field_buffer(f, 0, s.c_str()))
 	    ERROREX();
-	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD))
+	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD))
 	    ERROREX();
 	if (E_OK != field_opts_off(f, O_ACTIVE)) //статический текст
 	    ERROREX();
@@ -145,7 +145,7 @@ void AddProjectForm::genfields(int& line, Item* project) //создаст мас
 	    ERROREX();
 	if (E_OK != set_field_buffer(f, 0, s.c_str()))
 	    ERROREX();
-	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD))
+	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD))
 	    ERROREX();
 	if (E_OK != field_opts_off(f, O_ACTIVE)) //статический текст
 	    ERROREX();
@@ -163,7 +163,7 @@ void AddProjectForm::genfields(int& line, Item* project) //создаст мас
 	    ERROREX();
 	if (E_OK != set_field_buffer(f, 0, s.c_str()))
 	    ERROREX();
-	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD))
+	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD))
 	    ERROREX();
 	if (E_OK != field_opts_off(f, O_ACTIVE)) //статический текст
 	    ERROREX();
@@ -191,7 +191,7 @@ void AddProjectForm::genfields(int& line, Item* project) //создаст мас
 	    ERROREX();
 	if (E_OK != set_field_buffer(f, 0, s.c_str()))
 	    ERROREX();
-	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD))
+	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD))
 	    ERROREX();
 	if (E_OK != field_opts_off(f, O_ACTIVE)) //статический текст
 	    ERROREX();
@@ -204,7 +204,7 @@ void AddProjectForm::genfields(int& line, Item* project) //создаст мас
 	ERROREX();
     if (E_OK != set_field_buffer(f, 0, "email"))
 	ERROREX();
-    if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD))
+    if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD))
 	ERROREX();
     if (E_OK != field_opts_off(f, O_ACTIVE)) //статический текст
 	ERROREX();
@@ -223,7 +223,7 @@ void AddProjectForm::genfields(int& line, Item* project) //создаст мас
 	ERROREX();
     if (E_OK != set_field_buffer(f, 0, "password"))
 	ERROREX();
-    if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD))
+    if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD))
 	ERROREX();
     if (E_OK != field_opts_off(f, O_ACTIVE)) //статический текст
 	ERROREX();
@@ -244,7 +244,7 @@ void AddProjectForm::genfields(int& line, Item* project) //создаст мас
 	    ERROREX();
 	if (E_OK != set_field_buffer(f, 0, "username"))
 	    ERROREX();
-	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD))
+	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD))
 	    ERROREX();
 	if (E_OK != field_opts_off(f, O_ACTIVE)) //статический текст
 	    ERROREX();
@@ -263,7 +263,7 @@ void AddProjectForm::genfields(int& line, Item* project) //создаст мас
 	    ERROREX();
 	if (E_OK != set_field_buffer(f, 0, "teamname"))
 	    ERROREX();
-	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD))
+	if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD))
 	    ERROREX();
 	if (E_OK != field_opts_off(f, O_ACTIVE)) //статический текст
 	    ERROREX();
@@ -283,7 +283,7 @@ void AddProjectForm::genfields(int& line, Item* project) //создаст мас
 	ERROREX();
     if (E_OK != set_field_buffer(f, 0, "Enter-Ok    Esc-Cancel"))
 	ERROREX();
-    if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD))
+    if (E_OK != set_field_back(f, getcolorpair(COLOR_WHITE,-1) | A_BOLD))
 	ERROREX();
     if (E_OK != field_opts_off(f, O_ACTIVE)) //статический текст
 	ERROREX();

--- a/src/cfgform.cpp
+++ b/src/cfgform.cpp
@@ -51,7 +51,7 @@ void CfgForm::genfields(bool extfields) //создаст массив полей
     FIELD* field   = addfield(new_field(1, 44, nl, 5, 0, 0));
     field_opts_off(field, O_ACTIVE); //статический текст
     set_field_buffer(field, 0, "host             port   pwd");
-    set_field_back(field, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD);
+    set_field_back(field, getcolorpair(COLOR_WHITE,-1) | A_BOLD);
     nl = nl + 1;
     //поля для хостов
     for (i = 0; i < nhost; i++) //цикл по хостам
@@ -104,7 +104,7 @@ void CfgForm::genfields(bool extfields) //создаст массив полей
 	set_field_buffer(field, 0, "Esc-Cancel   Enter-Accept");
     else
 	set_field_buffer(field, 0, "Esc-Cancel   Enter-Accept   Ins-Add host");
-    set_field_back(field, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD);
+    set_field_back(field, getcolorpair(COLOR_WHITE,-1) | A_BOLD);
     nl = nl + 2;
     //финализация списка полей
     addfield(NULL);

--- a/src/helpwin.cpp
+++ b/src/helpwin.cpp
@@ -25,15 +25,15 @@ HelpWin::HelpWin(int rows, int cols) : NGroup(NRect(rows, cols, getmaxy(stdscr)/
     caption = strdup(" Hot keys list ");
     modalflag = true;
     resize(17,60);
-    wattrset(win,getcolorpair(COLOR_WHITE, COLOR_BLACK) | A_BOLD);
+    wattrset(win,getcolorpair(COLOR_WHITE, -1) | A_BOLD);
     if(asciilinedraw == 1)
 	wborder(win, '|', '|', '-', '-', '+', '+', '+', '+');
     else
 	box(win,0,0);
     mvwprintw(win,0,getwidth()/2-(strlen(caption)/2),caption);
     text1 = new NStaticText(NRect(getheight()-2,getwidth()-2,/*rect.begrow+*/1,/*rect.begcol+*/1));
-    int attr1 = getcolorpair(COLOR_YELLOW, COLOR_BLACK) | A_BOLD;
-    int attr2 = getcolorpair(COLOR_WHITE, COLOR_BLACK) | A_BOLD;
+    int attr1 = getcolorpair(COLOR_YELLOW, -1) | A_BOLD;
+    int attr2 = getcolorpair(COLOR_WHITE, -1) | A_BOLD;
     text1->setstring(attr1,   "\n   Common Controls:\n");
     text1->appendstring(attr2,"       \"N\"           - Toogle between BOINC hosts\n");
     text1->appendstring(attr2,"       \"C\"           - Edit configuration\n");

--- a/src/infopanel.cpp
+++ b/src/infopanel.cpp
@@ -63,7 +63,7 @@ void InfoPanel::refresh()
 	NView::refresh();
 	return;
     }
-    wattrset(win,getcolorpair(COLOR_WHITE,COLOR_BLACK));
+    wattrset(win,getcolorpair(COLOR_WHITE,-1));
     wattron(win, A_REVERSE);
     mvwprintw(win,0,0,"       Tasks        ");
     wattroff(win, A_REVERSE);
@@ -154,14 +154,14 @@ void InfoPanel::refresh()
 	if ( ( getheight()-line ) < needlines )
 	    break; //не выводим если осталось мало строк
 	//вывод на экран о проекте
-	wattrset(win,getcolorpair(COLOR_YELLOW,COLOR_BLACK));
+	wattrset(win,getcolorpair(COLOR_YELLOW,-1));
 	mvwprintw(win,line++,0,"%s\n",projects[i].name.c_str());
 	if (!projects[i].sstatus.empty())
 	{
-	    wattrset(win,getcolorpair(COLOR_RED,COLOR_BLACK));
+	    wattrset(win,getcolorpair(COLOR_RED,-1));
 	    mvwprintw(win,line++,0,"%s\n",projects[i].sstatus.c_str());
 	}
-	wattrset(win,getcolorpair(COLOR_WHITE,COLOR_BLACK));
+	wattrset(win,getcolorpair(COLOR_WHITE,-1));
 	if ( (!compact)||(abs(projects[i].user - projects[i].host) > 1) )
 	{
 	    mvwprintw(win,line++,0,"user total%10.0f\n",projects[i].user);

--- a/src/mainwin.cpp
+++ b/src/mainwin.cpp
@@ -51,7 +51,7 @@ MainWin::MainWin(NRect rect/*, Config* cfg*/) : NGroup(rect)
     colname.push_back("  application                   ");
     colname.push_back("  task");
     tablheader = new NStaticText(NRect(1, rect.cols -2-(INFPANWIDTH)-1, 1, 1));
-    tablheader->setstring(getcolorpair(COLOR_CYAN,COLOR_BLACK) | A_BOLD,"  #  state    done%%  project               est d/l   task");
+    tablheader->setstring(getcolorpair(COLOR_CYAN,-1) | A_BOLD,"  #  state    done%%  project               est d/l   task");
     int wtaskheight = getheight() * wtaskheightpercent / 10000.0;
     if (wtaskheight < 5)
 	wtaskheight = 5;
@@ -139,13 +139,13 @@ void MainWin::setcoltitle()
 	if (wtask->iscolvisible(i))
 	    s = s + colname[i];
     }
-    tablheader->setstring(getcolorpair(COLOR_CYAN,COLOR_BLACK) | A_BOLD, s.c_str());
+    tablheader->setstring(getcolorpair(COLOR_CYAN,-1) | A_BOLD, s.c_str());
 }
 
 
 void MainWin::refresh()
 {
-    wattrset(win, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD);
+    wattrset(win, getcolorpair(COLOR_WHITE,-1) | A_BOLD);
     if(asciilinedraw == 1)
 	wborder(win, '|', '|', '-', '-', '+', '+', '+', '+');
     else
@@ -161,7 +161,7 @@ void MainWin::refresh()
 	//wattrset(win,0);
     }
     //wborder(win, ACS_VLINE, ACS_VLINE, ACS_HLINE, ACS_HLINE, ACS_ULCORNER, ACS_URCORNER, ACS_LLCORNER, ACS_LRCORNER);
-    //wattroff(win, getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD);
+    //wattroff(win, getcolorpair(COLOR_WHITE,-1) | A_BOLD);
     NGroup::refresh();
 }
 
@@ -172,7 +172,7 @@ void MainWin::updatecaption()
     caption->clear();
     if (srv)
     {
-        caption->append(getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD," Host %s:%s ",srv->gethost(),srv->getport());
+        caption->append(getcolorpair(COLOR_WHITE,-1) | A_BOLD," Host %s:%s ",srv->gethost(),srv->getport());
         if (srv->loginfail)
             caption->append(getcolorpair(COLOR_WHITE,COLOR_RED) | A_BOLD,"unauthorized!");
         else

--- a/src/msgwin.cpp
+++ b/src/msgwin.cpp
@@ -71,10 +71,10 @@ void MsgWin::updatedata() //обновить данные с сервера
 		    sproject = project->getsvalue();
 		if ( (stimestamp != stimestampold)||(sproject != sprojectold)) //выводим имя и время проекта если они отличаются от предидущего
 		{
-		    //addstring(getcolorpair(COLOR_CYAN,COLOR_BLACK) /*| A_BOLD*/,"#%d %s ", number->getivalue(), tbuf); //номер и время сообщения
-		    addstring(getcolorpair(COLOR_CYAN,COLOR_BLACK) ,"%s ", tbuf); //время сообщения
+		    //addstring(getcolorpair(COLOR_CYAN,-1) /*| A_BOLD*/,"#%d %s ", number->getivalue(), tbuf); //номер и время сообщения
+		    addstring(getcolorpair(COLOR_CYAN,-1) ,"%s ", tbuf); //время сообщения
 		    //strcpy(tbufold, tbuf);
-		    content.back()->append(getcolorpair(COLOR_YELLOW,COLOR_BLACK),"%s",sproject.c_str()); //добавить имя проекта другим цветом
+		    content.back()->append(getcolorpair(COLOR_YELLOW,-1),"%s",sproject.c_str()); //добавить имя проекта другим цветом
 		    stimestampold = stimestamp;
 		    sprojectold = sproject;
 		}
@@ -86,7 +86,7 @@ void MsgWin::updatedata() //обновить данные с сервера
 		    s[slen-3] = '\0';
 		    ss = ss + 9;
 		}
-		addstring(getcolorpair(COLOR_WHITE,COLOR_BLACK), "%s", ss/*body->getsvalue()*/); //само сообщение
+		addstring(getcolorpair(COLOR_WHITE,-1), "%s", ss/*body->getsvalue()*/); //само сообщение
 		free(s);
 	    }
 	}

--- a/src/nform.cpp
+++ b/src/nform.cpp
@@ -31,7 +31,7 @@ NForm::NForm(int rows, int cols) : NGroup(NRect(rows,cols,0,0))
     set_form_win(frm, win);
     subwin = derwin(win, rows-2, cols-2, 1,1);
     set_form_sub(frm, subwin);
-    wattrset(win,getcolorpair(COLOR_WHITE, COLOR_BLACK) | A_BOLD);
+    wattrset(win,getcolorpair(COLOR_WHITE, -1) | A_BOLD);
     title = NULL;
     needrefresh = true;
     //перемещаем в центр экрана

--- a/src/nhline.cpp
+++ b/src/nhline.cpp
@@ -21,7 +21,7 @@
 void NHLine::refresh()
 {
     wbkgd(win,bgcolor);
-    wattrset(win,getcolorpair(COLOR_WHITE,COLOR_BLACK));
+    wattrset(win,getcolorpair(COLOR_WHITE,-1));
     if ( asciilinedraw == 1)
 	whline(win, '-', getwidth()-0);
     else

--- a/src/nmenu.cpp
+++ b/src/nmenu.cpp
@@ -26,9 +26,9 @@ NMenu::NMenu(NRect rect, bool horis) : NGroup(rect)
     ishoris = horis;
     posted = false;
     menu = new_menu(mitems);
-    setbackground(getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD);
+    setbackground(getcolorpair(COLOR_WHITE,-1) | A_BOLD);
     setforeground(getcolorpair(COLOR_BLACK,COLOR_WHITE));
-    set_menu_grey(menu, getcolorpair(COLOR_RED,COLOR_BLACK)); //цвет разделителей
+    set_menu_grey(menu, getcolorpair(COLOR_RED,-1)); //цвет разделителей
     set_menu_win(menu, win);
     postmenu();
     if (horis)

--- a/src/nmessagebox.cpp
+++ b/src/nmessagebox.cpp
@@ -114,12 +114,12 @@ NMessageBox::NMessageBox(const char* text) : NGroup(NRect(3, 40, 1, 1))
     while ( (*p != 0)&&(nbytes < bsize) ); //дошли до конца
     //заполняем содержимое
     content = new NStaticText(NRect(contentheight, getwidth()-4, 2, 2));
-    content->setbgcolor(getcolorpair(COLOR_WHITE, COLOR_BLACK));
+    content->setbgcolor(getcolorpair(COLOR_WHITE, -1));
     insert(content);
-    content->appendstring(getcolorpair(COLOR_WHITE, COLOR_BLACK) | A_BOLD, text);
+    content->appendstring(getcolorpair(COLOR_WHITE, -1) | A_BOLD, text);
     modalflag = true;
     resize(contentheight + 6,getwidth());
-    wattrset(win,getcolorpair(COLOR_WHITE, COLOR_BLACK) | A_BOLD);
+    wattrset(win,getcolorpair(COLOR_WHITE, -1) | A_BOLD);
     if(asciilinedraw == 1)
 	wborder(win, '|', '|', '-', '-', '+', '+', '+', '+');
     else

--- a/src/nscrollbar.cpp
+++ b/src/nscrollbar.cpp
@@ -58,7 +58,7 @@ void NScrollBar::setpos(int vmin, int vmax, int vpos1, int vpos2)
 void NScrollBar::refresh()
 {
     wbkgd(win,bgcolor);
-    wattrset(win,getcolorpair(COLOR_WHITE,COLOR_BLACK));
+    wattrset(win,getcolorpair(COLOR_WHITE,-1));
     chtype topsymbol = asciilinedraw ? '+'| (chtop & A_BOLD) : chtop;
     chtype bottomsymbol = asciilinedraw ? '+' | (chbottom & A_BOLD) : chbottom;
     chtype bodysymbol = asciilinedraw ? 'X' : ACS_CKBOARD;

--- a/src/nselectlist.cpp
+++ b/src/nselectlist.cpp
@@ -76,7 +76,7 @@ void NSelectList::drawcontent() //отрисовывает буфер строк
 	    {
 		wbkgdset(win,getcolorpair(COLOR_WHITE,selectorbgcolor));
 		wclrtoeol(win); //очищаем до конца строки
-		wbkgdset(win,getcolorpair(COLOR_WHITE, COLOR_BLACK));
+		wbkgdset(win,getcolorpair(COLOR_WHITE, -1));
 	    }
 	}
 	else //очищаем нижнюю незанятую часть окна (если есть)

--- a/src/nstatictext.h
+++ b/src/nstatictext.h
@@ -26,7 +26,7 @@
 class NStaticText : public NView
 {
   public:
-    NStaticText(NRect rect) : NView(rect) { content = new NColorString(0,""); align = 0; setbgcolor(getcolorpair(COLOR_WHITE,COLOR_BLACK));};
+    NStaticText(NRect rect) : NView(rect) { content = new NColorString(0,""); align = 0; setbgcolor(getcolorpair(COLOR_WHITE,-1));};
     virtual ~NStaticText() { delete content; };
     void appendstring(int attr, const char* fmt, ...);
     void setstring(int attr, const char* fmt, ...);

--- a/src/nview.cpp
+++ b/src/nview.cpp
@@ -73,7 +73,7 @@ NView::NView(NRect rect)
     #ifdef DEBUG
     refreshcount = 0; //счетчик обновлений
     #endif
-    wbkgdset(win,getcolorpair(COLOR_WHITE,COLOR_BLACK)); //бакграунд
+    wbkgdset(win,getcolorpair(COLOR_WHITE,-1)); //бакграунд
     werase(win); //заполняем цветом фона
 }
 

--- a/src/nvline.cpp
+++ b/src/nvline.cpp
@@ -21,7 +21,7 @@
 void NVLine::refresh()
 {
     wbkgd(win,bgcolor);
-    wattrset(win,getcolorpair(COLOR_WHITE,COLOR_BLACK));
+    wattrset(win,getcolorpair(COLOR_WHITE,-1));
     if (asciilinedraw == 1)
 	wvline(win, '|', getheight()-0);
     else

--- a/src/statwin.cpp
+++ b/src/statwin.cpp
@@ -139,7 +139,7 @@ void StatWin::updatedata()
 	//формируем содержимое окна на основе структуры projects
 	std::vector<ProjStat>::iterator itprj;
 	std::list<time_t> daylist; //для заголовков дней
-	NColorString* cs = new NColorString(getcolorpair(COLOR_CYAN, COLOR_BLACK) | A_BOLD, "  %-*s %-*s", COLWIDTH-2, "", COLWIDTH-2, "Summary");
+	NColorString* cs = new NColorString(getcolorpair(COLOR_CYAN, -1) | A_BOLD, "  %-*s %-*s", COLWIDTH-2, "", COLWIDTH-2, "Summary");
 	int n = hpos;
 	for (itprj = projects.begin(); itprj != projects.end(); itprj++, n--) //проекты
 	{
@@ -148,7 +148,7 @@ void StatWin::updatedata()
 	    std::string s = (*itprj).name.c_str();
 	    if (s.size() > COLWIDTH)
 		s.resize(COLWIDTH);
-	    cs->append(getcolorpair(COLOR_RED, COLOR_BLACK) | A_BOLD, " %*s ", COLWIDTH, s.c_str()); //имена проектов
+	    cs->append(getcolorpair(COLOR_RED, -1) | A_BOLD, " %*s ", COLWIDTH, s.c_str()); //имена проектов
 	    std::list<DayStat>::iterator itdays;
 	    for(itdays = (*itprj).days.begin(); itdays!=(*itprj).days.end(); itdays++)
 	    {
@@ -164,8 +164,8 @@ void StatWin::updatedata()
 	    tm* daytm = localtime(&(*itday));
 	    char buf[128] = "?";
 	    strftime(buf, sizeof(buf),"%-2e %b",daytm); //"%-e %b %-k:%M"
-	    NColorString* cs = new NColorString(getcolorpair(COLOR_WHITE, COLOR_BLACK) | A_BOLD, "%-*s", COLWIDTH, buf);
-	    cs->append(getcolorpair(COLOR_CYAN, COLOR_BLACK) | A_BOLD, " %*ld ", COLWIDTH, hostmode ? daysumhost[*itday] : daysumuser[*itday]);
+	    NColorString* cs = new NColorString(getcolorpair(COLOR_WHITE, -1) | A_BOLD, "%-*s", COLWIDTH, buf);
+	    cs->append(getcolorpair(COLOR_CYAN, -1) | A_BOLD, " %*ld ", COLWIDTH, hostmode ? daysumhost[*itday] : daysumuser[*itday]);
 	    n = hpos;
 	    for (itprj = projects.begin(); itprj != projects.end(); itprj++, n--) //перебрать все проекты по этому дню
 	    {
@@ -187,9 +187,9 @@ void StatWin::updatedata()
 		    }
 		}
 		if (value != -1)
-		    cs->append(getcolorpair(COLOR_WHITE, COLOR_BLACK) | A_BOLD, " %*ld ",COLWIDTH, value);
+		    cs->append(getcolorpair(COLOR_WHITE, -1) | A_BOLD, " %*ld ",COLWIDTH, value);
 		else
-		    cs->append(getcolorpair(COLOR_BLACK, COLOR_BLACK) | A_BOLD, " %*s ",COLWIDTH, "-");
+		    cs->append(getcolorpair(-1, -1) | A_BOLD, " %*s ",COLWIDTH, "-");
 	    }
 	    content->addstring(cs);
 	}

--- a/src/taskinfowin.cpp
+++ b/src/taskinfowin.cpp
@@ -290,10 +290,10 @@ void TaskInfoWin::updatedata()
     std::vector<std::pair<std::string, std::string> >::iterator it;
     for (it = ss.begin(); it!=ss.end(); it++)
     {
-	int varcolor = getcolorpair(COLOR_WHITE, COLOR_BLACK) | A_BOLD;
-	int valcolor = getcolorpair(COLOR_WHITE, COLOR_BLACK) | A_BOLD;
+	int varcolor = getcolorpair(COLOR_WHITE, -1) | A_BOLD;
+	int valcolor = getcolorpair(COLOR_WHITE, -1) | A_BOLD;
 	if ((FindVar(ssbak, (*it).first) != (*it).second)&&(!ssbak.empty()))
-	    valcolor = getcolorpair(COLOR_CYAN, COLOR_BLACK) | A_BOLD;
+	    valcolor = getcolorpair(COLOR_CYAN, -1) | A_BOLD;
 
 	NColorString* cs = new NColorString(varcolor, "%-*s   ", maxlen1, (*it).first.c_str());
 	cs->append(valcolor, "%s\n", (*it).second.c_str());

--- a/src/taskwin.cpp
+++ b/src/taskwin.cpp
@@ -411,23 +411,23 @@ void TaskWin::updatedata() //обновить данные с сервера
 	    if (name)
 	    {
 		int column = 0;
-		int attr = getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_NORMAL; //ставим цвет по умолчанию
+		int attr = getcolorpair(COLOR_WHITE,-1) | A_NORMAL; //ставим цвет по умолчанию
 		NColorString* cs = new NColorString(attr, "");
 		std::string sstate = getresultstatestr(*it); //состояние задачи
 		//цвет и атрибут в зависимости от состояния задачи
 		if ((*it)->findItem("ready_to_report") != NULL)
-		    attr = getcolorpair(COLOR_BLACK,COLOR_BLACK) | A_BOLD;
+		    attr = getcolorpair(-1,-1) | A_BOLD;
 		if ((*it)->findItem("active_task") != NULL)
-		    attr =  getcolorpair(COLOR_WHITE,COLOR_BLACK) | A_BOLD; //ставим цвет по умолчанию + A_BOLD;
+		    attr =  getcolorpair(COLOR_WHITE,-1) | A_BOLD; //ставим цвет по умолчанию + A_BOLD;
 		if ( sstate == "Run")
-		    attr = getcolorpair(COLOR_YELLOW,COLOR_BLACK) | A_BOLD;
+		    attr = getcolorpair(COLOR_YELLOW,-1) | A_BOLD;
 		if ( sstate == "Upld")
-		    attr = getcolorpair(COLOR_BLUE,COLOR_BLACK) | A_BOLD;
+		    attr = getcolorpair(COLOR_BLUE,-1) | A_BOLD;
 		if ( sstate == "Dwnld")
-		    attr = getcolorpair(COLOR_GREEN,COLOR_BLACK) | A_BOLD;
+		    attr = getcolorpair(COLOR_GREEN,-1) | A_BOLD;
 		int stateattr = attr;
 		if (( sstate == "DoneEr" ) || ( sstate == "Abort" ) || ( sstate == "WMem" ))
-		    stateattr = getcolorpair(COLOR_RED,COLOR_BLACK)/* | A_BOLD*/;
+		    stateattr = getcolorpair(COLOR_RED,-1)/* | A_BOLD*/;
 		//проверяем нужно-ли отображать эту задачу
 		if
 		( !(
@@ -453,11 +453,11 @@ void TaskWin::updatedata() //обновить данные с сервера
 		if (plan_class != NULL)
 		{
 		    if ((strstr(plan_class->getsvalue(),"ati") != NULL )||(strstr(plan_class->getsvalue(),"opencl") != NULL))
-			attrgpu = getcolorpair(COLOR_MAGENTA,COLOR_BLACK) | A_BOLD;
+			attrgpu = getcolorpair(COLOR_MAGENTA,-1) | A_BOLD;
 		    if (strstr(plan_class->getsvalue(),"cuda") != NULL )
-			attrgpu = getcolorpair(COLOR_GREEN,COLOR_BLACK) | A_BOLD;
+			attrgpu = getcolorpair(COLOR_GREEN,-1) | A_BOLD;
 		    if (strstr(plan_class->getsvalue(),"intel") != NULL ) //NEED CHECK !!!
-			attrgpu = getcolorpair(COLOR_BLUE,COLOR_BLACK) | A_BOLD;
+			attrgpu = getcolorpair(COLOR_BLUE,-1) | A_BOLD;
 		}
 		if (( sstate != "Run" )||( sstate != "Done"))
 		//    attrgpu = attrgpu & (~A_BOLD); //выключаем болд для незапущенных
@@ -478,7 +478,7 @@ void TaskWin::updatedata() //обновить данные с сервера
 		    {
 			double dtime = estimated_cpu_time_remaining->getdvalue();
 			if ( ( sstate == "Run" )&&( dtime < 600)&&( dtime >= 0 ) ) //осталось [0-600[ сек
-			    attr2 = getcolorpair(COLOR_RED,COLOR_BLACK) | A_BOLD;
+			    attr2 = getcolorpair(COLOR_RED,-1) | A_BOLD;
 			if ( dtime >= 0)
 			    cs->append(attr2," %6s", gethumanreadabletimestr(dtime).c_str()); //естимейт
 			else
@@ -497,7 +497,7 @@ void TaskWin::updatedata() //обновить данные с сервера
 			double dtime = report_deadline->getdvalue();
 			double beforedl = dtime - time(NULL); //число секунд до дедлайна
 			if ( ( sstate != "Done")&&( beforedl < 3600 * 24 * 2) ) //осталось меньше 2-х дней
-			    attr2 = getcolorpair(COLOR_BLUE,COLOR_BLACK) | A_BOLD;
+			    attr2 = getcolorpair(COLOR_BLUE,-1) | A_BOLD;
 			cs->append(attr2," %6s", (beforedl>0) ? gethumanreadabletimestr(beforedl).c_str() : "dead");
 		    }
 		    else

--- a/src/tui-main.cpp
+++ b/src/tui-main.cpp
@@ -41,6 +41,7 @@ void initcurses()
     mousemask(ALL_MOUSE_EVENTS, NULL); // Report all mouse events
     #endif
     timeout(100); //ожидание для getch() 100 милисекунд
+    use_default_colors(); // enable use of default colors for transparency
     start_color();
 }
 


### PR DESCRIPTION
A change that isn’t good for me on an iOS terminal client, but may be for other folk who are using a window manager to drive their terminal windows.